### PR TITLE
udpating firebase and slapp modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,24 @@ Expects the following environment variables:
 + `SLACK_CLIENT_ID` - Your Slack App's Client ID
 + `SLACK_CLIENT_SECRET` - Your Slack App's Client Secret
 + `FIREBASE_DB_URL` - Your Firebase project's Database URL
++ `FIREBASE_SERVICE_ACCOUNT_BASE64` - Your Firebase project's ID
 
-Also expected is a [Firebase Service account key file](https://firebase.google.com/docs/server/setup) located in the root of the project, named `firebase.json`.
+To create your `FIREBASE_SERVICE_ACCOUNT_BASE64` value you'll want to head to your Firebase project's Service Accounts settings and generate a new Private Key `json` file.  You'll need to base64 encode the contents of the file to be able to set it as an environment variable.
+
+```bash
+base64 /path/to/service-account.json
+```
+
+For development you can set your environment variables in an `env.sh` file (which is `.gitignored` for you), and then just source it.
+
+```bash
+export PORT="8080"
+export SLACK_VERIFY_TOKEN="your-slack-verify-token"
+export SLACK_CLIENT_ID="your-slack-app-client-id"
+export SLACK_CLIENT_SECRET="your-slack-app-client-secret"
+export FIREBASE_DB_URL="your-firebase-url"
+export FIREBASE_SERVICE_ACCOUNT_BASE64="base64 encoded service account key file contents"
+```
 
 ## Getting Started
 
@@ -23,7 +39,7 @@ You'll need to setup a [new Slack App](https://api.slack.com/apps/new) and add a
     * `message.im`
     * `message.mpim`
 
-A [Firebase](firebase) project is also required.  Slack Team data from the "Add to Slack" OAuth flow, as well as conversation state is stored there. Make sure to add your service account key file as `firebase.json` and set your `FIREBASE_DB_URL` environment variable.
+A [Firebase](firebase) project is also required.  Slack Team data from the "Add to Slack" OAuth flow, as well as conversation state is stored there.
 
 ## Running App
 Once you have your app running, if you visit the root, `https://<your-domain>/` it will render a page with an "Add to Slack" button you can use to add it to one of your Slack teams and start sending it messages.

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,12 +1,14 @@
 'use strict'
 
-const path = require('path')
-const firebase = require('firebase')
+const firebase = require('firebase-admin')
 
 module.exports = () => {
+  const firebaseDBUrl = process.env.FIREBASE_DB_URL
+  const serviceAccountBase64 = process.env.FIREBASE_SERVICE_ACCOUNT_BASE64
+
   firebase.initializeApp({
-    serviceAccount: path.join(__dirname, '..', 'firebase.json'),
-    databaseURL: process.env.FIREBASE_DB_URL
+    credential: firebase.credential.cert(b64ToObject(serviceAccountBase64)),
+    databaseURL: firebaseDBUrl
   })
 
   let database = firebase.database()
@@ -48,4 +50,8 @@ module.exports = () => {
       database.ref(`convos/${id}`).remove(done)
     }
   }
+}
+
+function b64ToObject (b64) {
+  return !b64 ? {} : JSON.parse(Buffer.from(b64, 'base64').toString('ascii'))
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "firebase": "^3.2.1",
-    "slapp": "^1.0.3"
+    "firebase-admin": "^4.0.6",
+    "slapp": "^2.0.1"
   },
   "devDependencies": {
     "standard": "^7.1.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "firebase-admin": "^4.0.6",
-    "slapp": "^2.0.1"
+    "slapp": "^2.1.0"
   },
   "devDependencies": {
     "standard": "^7.1.2"


### PR DESCRIPTION
This updates `slapp` to the latest version and updates to the `firebase-admin` module.  This allows us to pass in the firebase credentials as an object instead of needing a file read from disk.

Addresses Issue #1 